### PR TITLE
Feat/add lab 1

### DIFF
--- a/Module-1/Examples/.terraform.lock.hcl
+++ b/Module-1/Examples/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.32.0"
+  constraints = "~> 4.32.0"
+  hashes = [
+    "h1:Xb5EIjnFtbdOSF1+eTdrx+vYKU2fjZyqWiLUQElqxOQ=",
+    "zh:0ca3ad43d30e05222f53fcccfec912920a65d075c2acaeb2226f6ffad153df13",
+    "zh:0f8b71cfc4a158809251f7c16cfd808f4b58f4fc9519cee53ab1b6566cdcc496",
+    "zh:21f6766f79e3d096f480afb3cba2ff10e25cce6c26ceb97b2db720111f0593ce",
+    "zh:382845ee360f92448d3512aae3249b20078e5f65c4dd0b6eacd9fba4c79c8694",
+    "zh:43949a72782d2a3283f5c0dfc966612a4f9b8c031688dd1ef326514defcaed31",
+    "zh:453e02e206ea03f9607e68e35c5da561b2f80d2cd62842c3c8e85e4b6ce1535a",
+    "zh:525fedbc0ae6a2c7523a354c9ba4e1174485d03426f8ab4f86522961e94f8e8a",
+    "zh:673615eb2a333dcf2b6d656d0e8730cae2f6b41cc18ea874ab5e1e95993b0892",
+    "zh:7118a1c25c3b1cd3a8a3878fef1580703914ee211fee59d34d5ad922e70bb749",
+    "zh:c71918ee0fc519ecbb44da56423aea5cb68315f9033f9e817b01abd30f50dd97",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f5777fb86d78faafa9f31d7f0526932a142725a04e7fe6a555d40cf2ef4589b7",
+  ]
+}

--- a/Module-1/Examples/main.tf
+++ b/Module-1/Examples/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${var.project}-${var.environment}"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = "sa${var.project}${var.environment}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}

--- a/Module-1/Examples/providers.tf
+++ b/Module-1/Examples/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.12.1"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.32.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = "ffbf501f-f220-4b59-8d0a-5068d961cc5f"
+}

--- a/Module-1/Examples/variables.tf
+++ b/Module-1/Examples/variables.tf
@@ -1,0 +1,16 @@
+variable "project" {
+  description = "The name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "The deployment environment (e.g., dev, test, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region to deploy to"
+  type        = string
+}
+
+

--- a/Module-1/Lab/.terraform.lock.hcl
+++ b/Module-1/Lab/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.32.0"
+  constraints = "~> 4.32.0"
+  hashes = [
+    "h1:Xb5EIjnFtbdOSF1+eTdrx+vYKU2fjZyqWiLUQElqxOQ=",
+    "zh:0ca3ad43d30e05222f53fcccfec912920a65d075c2acaeb2226f6ffad153df13",
+    "zh:0f8b71cfc4a158809251f7c16cfd808f4b58f4fc9519cee53ab1b6566cdcc496",
+    "zh:21f6766f79e3d096f480afb3cba2ff10e25cce6c26ceb97b2db720111f0593ce",
+    "zh:382845ee360f92448d3512aae3249b20078e5f65c4dd0b6eacd9fba4c79c8694",
+    "zh:43949a72782d2a3283f5c0dfc966612a4f9b8c031688dd1ef326514defcaed31",
+    "zh:453e02e206ea03f9607e68e35c5da561b2f80d2cd62842c3c8e85e4b6ce1535a",
+    "zh:525fedbc0ae6a2c7523a354c9ba4e1174485d03426f8ab4f86522961e94f8e8a",
+    "zh:673615eb2a333dcf2b6d656d0e8730cae2f6b41cc18ea874ab5e1e95993b0892",
+    "zh:7118a1c25c3b1cd3a8a3878fef1580703914ee211fee59d34d5ad922e70bb749",
+    "zh:c71918ee0fc519ecbb44da56423aea5cb68315f9033f9e817b01abd30f50dd97",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f5777fb86d78faafa9f31d7f0526932a142725a04e7fe6a555d40cf2ef4589b7",
+  ]
+}

--- a/Module-1/Lab/main.tf
+++ b/Module-1/Lab/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${var.project}"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = var.storage_account_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}

--- a/Module-1/Lab/providers.tf
+++ b/Module-1/Lab/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.12.1"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.32.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = "ffbf501f-f220-4b59-8d0a-5068d961cc5f"
+}

--- a/Module-1/Lab/variables.tf
+++ b/Module-1/Lab/variables.tf
@@ -1,0 +1,20 @@
+variable "project" {
+  description = "The name of the project"
+  type        = string
+  default     = "hiddelab1"
+}
+
+
+variable "location" {
+  description = "Azure region to deploy to"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "storage_account_name" {
+  description = "The name of the storage account"
+  type        = string
+  default     = "sahiddelab1"
+}
+
+


### PR DESCRIPTION
This pull request introduces Terraform configurations for deploying Azure resources in two contexts: an "Examples" module and a "Lab" module. The changes include defining resource groups and storage accounts, specifying required providers, and adding variables for customization.

### Terraform Configuration for Azure Resources:

#### Examples Module:
* Added a resource group and storage account configuration in `main.tf`, parameterized by project name, environment, and location variables.
* Defined required provider settings and Azure subscription details in `providers.tf`.
* Introduced variables for project name, environment, and location in `variables.tf`.
* Included a `.terraform.lock.hcl` file to lock the provider version and ensure reproducible builds.

#### Lab Module:
* Added a resource group and storage account configuration in `main.tf`, parameterized by project name, location, and storage account name variables.
* Defined required provider settings and Azure subscription details in `providers.tf`.
* Introduced variables for project name, location, and storage account name with default values in `variables.tf`.
* Included a `.terraform.lock.hcl` file to lock the provider version and ensure reproducible builds.